### PR TITLE
bugfix: json encoding of stores

### DIFF
--- a/meerkat/env.py
+++ b/meerkat/env.py
@@ -1,0 +1,111 @@
+"""Adapted from https://github.com/ad12/meddlr/blob/main/meddlr/utils/env.py."""
+import importlib
+import sys
+from packaging import version
+from importlib import util
+import re
+
+
+_SUPPORTED_PACKAGES = {}
+
+
+def package_available(name: str) -> bool:
+    """Returns if package is available.
+
+    Args:
+        name (str): Name of the package.
+
+    Returns:
+        bool: Whether module exists in environment.
+    """
+    global _SUPPORTED_PACKAGES
+    if name not in _SUPPORTED_PACKAGES:
+        _SUPPORTED_PACKAGES[name] = importlib.util.find_spec(name) is not None
+    return _SUPPORTED_PACKAGES[name]
+
+
+def get_package_version(package_or_name) -> str:
+    """Returns package version.
+
+    Args:
+        package_or_name (``module`` or ``str``): Module or name of module.
+            This package must have the version accessible through
+            ``<module>.__version__``.
+
+    Returns:
+        str: The package version.
+
+    Examples:
+        >>> get_version("numpy")
+        "1.20.0"
+    """
+    if isinstance(package_or_name, str):
+        if not package_available(package_or_name):
+            raise ValueError(f"Package {package_or_name} not available")
+        spec = util.find_spec(package_or_name)
+        package_or_name = util.module_from_spec(spec)
+        spec.loader.exec_module(package_or_name)
+    version = package_or_name.__version__
+    return version
+
+
+def is_package_installed(pkg_str) -> bool:
+    """
+    Verify that a package dependency is installed and
+    in the expected version range.
+
+    This is useful for optional third-party dependencies where implementation
+    changes are not backwards-compatible.
+
+    Args:
+        pkg_str (str): The pip formatted dependency string.
+            E.g. "numpy", "numpy>=1.0.0", "numpy>=1.0.0,<=1.10.0", "numpy==1.10.0"
+
+    Returns:
+        bool: Whether dependency is satisfied.
+
+    Note:
+        This cannot resolve packages where the pip name does not match the python
+        package name. ``'-'`` characters are automatically changed to ``'_'``.
+    """
+    ops = {
+        "==": lambda x, y: x == y,
+        "<=": lambda x, y: x <= y,
+        ">=": lambda x, y: x >= y,
+        "<": lambda x, y: x < y,
+        ">": lambda x, y: x > y,
+    }
+    comparison_patterns = "(==|<=|>=|>|<)"
+
+    pkg_str = pkg_str.strip()
+    pkg_str = pkg_str.replace("-", "_")
+    dependency = list(re.finditer(comparison_patterns, pkg_str))
+
+    if len(dependency) == 0:
+        return package_available(pkg_str)
+
+    pkg_name = pkg_str[: dependency[0].start()]
+    if not package_available(pkg_name):
+        return False
+
+    pkg_version = version.Version(get_package_version(pkg_name))
+    version_limits = pkg_str[dependency[0].start() :].split(",")
+
+    for vlimit in version_limits:
+        comp_loc = list(re.finditer(comparison_patterns, vlimit))
+        if len(comp_loc) != 1:
+            raise ValueError(f"Invalid version string: {pkg_str}")
+        comp_op = vlimit[comp_loc[0].start() : comp_loc[0].end()]
+        comp_version = version.Version(vlimit[comp_loc[0].end() :])
+        if not ops[comp_op](pkg_version, comp_version):
+            return False
+    return True
+
+
+def is_torch_available() -> bool:
+    """Returns if torch is available.
+
+    Returns:
+        bool: Whether torch is available.
+    """
+    return package_available("torch")

--- a/meerkat/env.py
+++ b/meerkat/env.py
@@ -1,10 +1,10 @@
-"""Adapted from https://github.com/ad12/meddlr/blob/main/meddlr/utils/env.py."""
+"""Adapted from
+https://github.com/ad12/meddlr/blob/main/meddlr/utils/env.py."""
 import importlib
-import sys
-from packaging import version
-from importlib import util
 import re
+from importlib import util
 
+from packaging import version
 
 _SUPPORTED_PACKAGES = {}
 
@@ -50,9 +50,8 @@ def get_package_version(package_or_name) -> str:
 
 
 def is_package_installed(pkg_str) -> bool:
-    """
-    Verify that a package dependency is installed and
-    in the expected version range.
+    """Verify that a package dependency is installed and in the expected
+    version range.
 
     This is useful for optional third-party dependencies where implementation
     changes are not backwards-compatible.

--- a/meerkat/interactive/api/routers/endpoint.py
+++ b/meerkat/interactive/api/routers/endpoint.py
@@ -8,6 +8,7 @@ from fastapi.encoders import jsonable_encoder
 
 from meerkat.columns.abstract import Column
 from meerkat.interactive.endpoint import Endpoint, endpoint
+from meerkat.interactive.utils import get_custom_json_encoder
 from meerkat.tools.lazy_loader import LazyLoader
 
 torch = LazyLoader("torch")
@@ -55,15 +56,5 @@ def dispatch(
     # Need to support sending back numpy arrays, torch tensors, and pandas series
     return jsonable_encoder(
         {"result": result, "modifications": modifications, "error": None},
-        custom_encoder={
-            np.ndarray: lambda v: v.tolist(),
-            torch.Tensor: lambda v: v.tolist(),
-            pd.Series: lambda v: v.tolist(),
-            Column: lambda v: v.to_json(),
-            np.int64: lambda v: int(v),
-            np.float64: lambda v: float(v),
-            np.int32: lambda v: int(v),
-            np.bool_: lambda v: bool(v),
-            np.bool8: lambda v: bool(v),
-        },
+        custom_encoder=get_custom_json_encoder(),
     )

--- a/meerkat/interactive/api/routers/endpoint.py
+++ b/meerkat/interactive/api/routers/endpoint.py
@@ -1,12 +1,9 @@
 import logging
 import traceback
 
-import numpy as np
-import pandas as pd
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
-from meerkat.columns.abstract import Column
 from meerkat.interactive.endpoint import Endpoint, endpoint
 from meerkat.interactive.utils import get_custom_json_encoder
 from meerkat.tools.lazy_loader import LazyLoader

--- a/meerkat/interactive/api/routers/page.py
+++ b/meerkat/interactive/api/routers/page.py
@@ -1,8 +1,5 @@
-import numpy as np
-import pandas as pd
 from fastapi.encoders import jsonable_encoder
 
-from meerkat.columns.abstract import Column
 from meerkat.interactive import Page
 from meerkat.interactive.endpoint import endpoint
 from meerkat.interactive.utils import get_custom_json_encoder

--- a/meerkat/interactive/api/routers/page.py
+++ b/meerkat/interactive/api/routers/page.py
@@ -5,6 +5,7 @@ from fastapi.encoders import jsonable_encoder
 from meerkat.columns.abstract import Column
 from meerkat.interactive import Page
 from meerkat.interactive.endpoint import endpoint
+from meerkat.interactive.utils import get_custom_json_encoder
 from meerkat.tools.lazy_loader import LazyLoader
 
 torch = LazyLoader("torch")
@@ -17,12 +18,5 @@ def config(page: Page):
         # here. This is a temp workaround to avoid getting an
         # exception in the notebook.
         page.frontend if isinstance(page, Page) else page,
-        custom_encoder={
-            np.ndarray: lambda v: v.tolist(),
-            torch.Tensor: lambda v: v.tolist(),
-            pd.Series: lambda v: v.tolist(),
-            Column: lambda v: v.to_json(),
-            np.int64: lambda v: int(v),
-            np.float64: lambda v: float(v),
-        },
+        custom_encoder=get_custom_json_encoder(),
     )

--- a/meerkat/interactive/api/routers/store.py
+++ b/meerkat/interactive/api/routers/store.py
@@ -10,6 +10,7 @@ from meerkat.columns.abstract import Column
 from meerkat.interactive.endpoint import Endpoint, endpoint
 from meerkat.interactive.graph import Store, trigger
 from meerkat.interactive.modification import StoreModification
+from meerkat.interactive.utils import get_custom_json_encoder
 from meerkat.state import state
 from meerkat.tools.lazy_loader import LazyLoader
 
@@ -66,15 +67,5 @@ def update(store: Store, value=Endpoint.EmbeddedBody()):
     # Return the modifications
     return jsonable_encoder(
         modifications,
-        custom_encoder={
-            np.ndarray: lambda v: v.tolist(),
-            torch.Tensor: lambda v: v.tolist(),
-            pd.Series: lambda v: v.tolist(),
-            Column: lambda v: v.to_json(),
-            np.int64: lambda v: int(v),
-            np.float64: lambda v: float(v),
-            np.int32: lambda v: int(v),
-            np.bool_: lambda v: bool(v),
-            np.bool8: lambda v: bool(v),
-        },
+        custom_encoder=get_custom_json_encoder(),
     )

--- a/meerkat/interactive/api/routers/store.py
+++ b/meerkat/interactive/api/routers/store.py
@@ -1,12 +1,9 @@
 import logging
 import traceback
 
-import numpy as np
-import pandas as pd
 from fastapi import HTTPException
 from fastapi.encoders import jsonable_encoder
 
-from meerkat.columns.abstract import Column
 from meerkat.interactive.endpoint import Endpoint, endpoint
 from meerkat.interactive.graph import Store, trigger
 from meerkat.interactive.modification import StoreModification

--- a/meerkat/interactive/graph/store.py
+++ b/meerkat/interactive/graph/store.py
@@ -2,6 +2,8 @@ import logging
 import warnings
 from typing import Any, Generic, Iterator, List, Tuple, TypeVar, Union
 
+from fastapi.encoders import jsonable_encoder
+
 from pydantic import BaseModel, ValidationError
 from pydantic.fields import ModelField
 from wrapt import ObjectProxy
@@ -12,6 +14,7 @@ from meerkat.interactive.graph.reactivity import reactive
 from meerkat.interactive.modification import StoreModification
 from meerkat.interactive.node import NodeMixin
 from meerkat.interactive.types import Storeable
+from meerkat.interactive.utils import get_custom_json_encoder
 from meerkat.mixins.identifiable import IdentifiableMixin
 from meerkat.mixins.reactifiable import MarkableMixin
 
@@ -57,8 +60,9 @@ class Store(IdentifiableMixin, NodeMixin, MarkableMixin, Generic[T], ObjectProxy
     def value(self):
         return self.__wrapped__
 
-    def to_json(self):
-        return self.__wrapped__
+    def to_json(self) -> Any:
+        """Converts the wrapped object into a jsonifiable object."""
+        return jsonable_encoder(self.__wrapped__, custom_encoder=get_custom_json_encoder())
 
     @property
     def frontend(self):

--- a/meerkat/interactive/graph/store.py
+++ b/meerkat/interactive/graph/store.py
@@ -3,7 +3,6 @@ import warnings
 from typing import Any, Generic, Iterator, List, Tuple, TypeVar, Union
 
 from fastapi.encoders import jsonable_encoder
-
 from pydantic import BaseModel, ValidationError
 from pydantic.fields import ModelField
 from wrapt import ObjectProxy
@@ -62,7 +61,9 @@ class Store(IdentifiableMixin, NodeMixin, MarkableMixin, Generic[T], ObjectProxy
 
     def to_json(self) -> Any:
         """Converts the wrapped object into a jsonifiable object."""
-        return jsonable_encoder(self.__wrapped__, custom_encoder=get_custom_json_encoder())
+        return jsonable_encoder(
+            self.__wrapped__, custom_encoder=get_custom_json_encoder()
+        )
 
     @property
     def frontend(self):

--- a/meerkat/interactive/utils.py
+++ b/meerkat/interactive/utils.py
@@ -1,10 +1,12 @@
-import rich
+from typing import Callable, Dict, Type
+
 import numpy as np
 import pandas as pd
+import rich
+
+from meerkat.env import is_torch_available
 from meerkat.interactive.graph.reactivity import reactive
 from meerkat.tools.lazy_loader import LazyLoader
-from meerkat.env import is_torch_available
-from typing import Dict, Type, Callable
 
 torch = LazyLoader("torch")
 

--- a/meerkat/interactive/utils.py
+++ b/meerkat/interactive/utils.py
@@ -1,5 +1,28 @@
 import rich
-
+import numpy as np
+import pandas as pd
+from meerkat.columns.abstract import Column
 from meerkat.interactive.graph.reactivity import reactive
+from meerkat.tools.lazy_loader import LazyLoader
+from meerkat.env import is_torch_available
+from typing import Dict, Type, Callable
+
+torch = LazyLoader("torch")
 
 print = reactive(rich.print)
+
+def get_custom_json_encoder() -> Dict[Type, Callable]:
+    custom_encoder = {
+        np.ndarray: lambda v: v.tolist(),
+        pd.Series: lambda v: v.tolist(),
+        Column: lambda v: v.to_json(),
+        np.int64: lambda v: int(v),
+        np.float64: lambda v: float(v),
+        np.int32: lambda v: int(v),
+        np.bool_: lambda v: bool(v),
+        np.bool8: lambda v: bool(v),
+    }
+
+    if is_torch_available():
+        custom_encoder[torch.Tensor] = lambda v: v.tolist()
+    return custom_encoder

--- a/meerkat/interactive/utils.py
+++ b/meerkat/interactive/utils.py
@@ -1,7 +1,6 @@
 import rich
 import numpy as np
 import pandas as pd
-from meerkat.columns.abstract import Column
 from meerkat.interactive.graph.reactivity import reactive
 from meerkat.tools.lazy_loader import LazyLoader
 from meerkat.env import is_torch_available
@@ -11,7 +10,11 @@ torch = LazyLoader("torch")
 
 print = reactive(rich.print)
 
+
 def get_custom_json_encoder() -> Dict[Type, Callable]:
+    from meerkat.columns.abstract import Column
+    from meerkat.interactive.graph.store import Store
+
     custom_encoder = {
         np.ndarray: lambda v: v.tolist(),
         pd.Series: lambda v: v.tolist(),
@@ -21,6 +24,7 @@ def get_custom_json_encoder() -> Dict[Type, Callable]:
         np.int32: lambda v: int(v),
         np.bool_: lambda v: bool(v),
         np.bool8: lambda v: bool(v),
+        Store: lambda v: v.to_json(),
     }
 
     if is_torch_available():

--- a/tests/meerkat/interactive/test_util.py
+++ b/tests/meerkat/interactive/test_util.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+import torch
+from fastapi.encoders import jsonable_encoder
+
+from meerkat.interactive.app.src.lib.component.core.match import MatchCriterion
+from meerkat.interactive.graph.store import Store
+from meerkat.interactive.utils import get_custom_json_encoder
+
+
+@pytest.mark.parametrize(
+    "obj,expected",
+    [
+        # torch
+        (torch.as_tensor([1, 2, 3]), [1, 2, 3]),
+        (torch.as_tensor([1, 2, 3]).float(), [1.0, 2.0, 3.0]),
+        # numpy
+        (np.array([1, 2, 3]), [1, 2, 3]),
+        (np.array([1, 2, 3]).astype(np.float32), [1.0, 2.0, 3.0]),
+        (np.array(["foo", "bar"]), ["foo", "bar"]),
+        (np.array([[1.0, 2.0, 3.0]]), [[1.0, 2.0, 3.0]]),
+        (np.asarray(1.0), 1.0),
+        (np.asarray(1).astype(np.float16), 1.0),
+        (np.asarray(1).astype(np.float32), 1.0),
+        (np.asarray(1).astype(np.float64), 1.0),
+        (np.asarray(1).astype(np.int8), 1),
+        (np.asarray(1).astype(np.int16), 1),
+        (np.asarray(1).astype(np.int32), 1),
+        (np.asarray(1).astype(np.int64), 1),
+    ],
+)
+@pytest.mark.parametrize("use_store", [False, True])
+def test_custom_json_encoder_native_objects(obj, expected, use_store: bool):
+    if use_store:
+        obj = Store(obj)
+
+    out = jsonable_encoder(obj, custom_encoder=get_custom_json_encoder())
+    np.testing.assert_equal(out, expected)
+
+
+@pytest.mark.parametrize(
+    "obj,expected",
+    [
+        (
+            MatchCriterion(
+                against="foo",
+                query="my query",
+                name="my name",
+                query_embedding=np.asarray([1, 2, 3]),
+                positives=[1, 2, 3, 4],
+                negatives=[5, 6, 7, 8],
+            ),
+            {
+                "against": "foo",
+                "query": "my query",
+                "name": "my name",
+                "query_embedding": [1, 2, 3],
+                "positives": [1, 2, 3, 4],
+                "negatives": [5, 6, 7, 8],
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize("use_store", [False, True])
+def test_custom_json_encoder_custom_objects(obj, expected, use_store: bool):
+    if use_store:
+        obj = Store(obj)
+    out = jsonable_encoder(obj, custom_encoder=get_custom_json_encoder())
+    np.testing.assert_equal(out, expected)
+
+
+@pytest.mark.parametrize(
+    "obj,expected",
+    [
+        (Store(Store([1, 2, 3])), [1, 2, 3]),
+        (Store((Store([1, 2, 3]), Store([4, 5, 6]))), [[1, 2, 3], [4, 5, 6]]),
+        (Store({"foo": Store([1, 2, 3])}), {"foo": [1, 2, 3]}),
+    ],
+)
+def test_custom_json_encoder_nested_stores(obj, expected):
+    out = jsonable_encoder(obj, custom_encoder=get_custom_json_encoder())
+    np.testing.assert_equal(out, expected)


### PR DESCRIPTION
On some Linux machines, encoding of stores was not working.

This may be because the json encoding was not recursive. `Store.to_json()` returned the wrapped object. If the encoding was recursive, the encoding would have been applied to the wrapped object. If it is not recursive, `iter` was called on the store object, which would fail.

## Fix
Have `Store.to_json` return the json encoded object in a recursive way.

## Verified
Verified the issue was fixed on a Ubuntu 22.04 machine

## Miscellaneous
- Add utilities for managing packages and environment information in meerkat