### PR TITLE
Pin jupyter==8.12 in linting ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,12 @@ jobs:
                     key: ${{ runner.os }}-pip
 
             -   name: Install Dependencies
+                # Pinning the ipython version because for some reason it's being upgraded
+                # even for python 3.8.
+                # TODO: Figure out why this is the case.
                 run: |
                     python -m pip install --upgrade pip
+                    pip install ipython==8.12
                     make dev
 
             -   name: Lint with isort, black, docformatter, flake8


### PR DESCRIPTION
The CI is downloading ipython=8.13 even for python 3.8, which is not supported

pin the version in the CI to skirt this issue, for now