### PR TITLE
`ipython=8.13` is installed for python=3.8 though its not supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,8 @@ jobs:
                     key: ${{ runner.os }}-pip
 
             -   name: Install Dependencies
-                # Pinning the ipython version because for some reason it's being upgraded
-                # even for python 3.8.
-                # TODO: Figure out why this is the case.
                 run: |
                     python -m pip install --upgrade pip
-                    pip install ipython==8.12
                     make dev
 
             -   name: Lint with isort, black, docformatter, flake8
@@ -157,11 +153,7 @@ jobs:
                     key: ${{ runner.os }}-pip
     
             -   name: Install Dependencies
-                # Pinning the ipython version because for some reason it's being upgraded
-                # even for python 3.8.
-                # TODO: Figure out why this is the case.
                 run: |
-                    pip install ipython==8.12
                     pip install -e ".[all]"
                     
             -   name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
                 run: |
                     python -m pip install --upgrade pip
                     make dev
+                    pip install IPython==8.12.0
 
             -   name: Lint with isort, black, docformatter, flake8
                 run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,11 @@ jobs:
                     key: ${{ runner.os }}-pip
     
             -   name: Install Dependencies
+                # Pinning the ipython version because for some reason it's being upgraded
+                # even for python 3.8.
+                # TODO: Figure out why this is the case.
                 run: |
+                    pip install ipython==8.12
                     pip install -e ".[all]"
                     
             -   name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
                 with:
                     path: ~/.cache/pip
                     key: ${{ runner.os }}-pip
-    
+
             -   name: Install Dependencies
                 run: |
                     pip install -e ".[all]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,12 @@ jobs:
                     key: ${{ runner.os }}-pip
 
             -   name: Install Dependencies
+                # Pinning the ipython version because for some reason it's being upgraded
+                # even for python 3.8.
+                # TODO: Figure out why this is the case.
                 run: |
                     python -m pip install --upgrade pip
+                    pip install ipython==8.12
                     make dev
 
             -   name: Lint with isort, black, docformatter, flake8

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Upgrade pip
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,8 @@
 sphinx_autodoc_typehints
 nbsphinx
 toml
-ipython
+ipython<8.13.0; python_version <= "3.8" # https://github.com/ipython/ipython/issues/14053
+ipython; python_version >= "3.9"
 jupyter-sphinx==0.4.0
 sphinx-panels
 sphinx-autobuild

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,15 @@ ver_path = convert_path("meerkat/version.py")
 with open(ver_path) as ver_file:
     exec(ver_file.read(), main_ns)
 
+# Restrict ipython version based on the python version.
+# https://github.com/ipython/ipython/issues/14053
+# TODO: Remove this once the wheel is pushed up.
+if sys.version_info[0] == 3 and sys.version_info[1] <= 8:
+    ipython_requirement = "IPython<8.13.0"
+else:
+    # python >= 3.9
+    ipython_requirement = "IPython"
+
 
 # Package meta-data.
 NAME = "meerkat-ml"
@@ -52,7 +61,7 @@ REQUIRED = [
     "progressbar>=2.5",
     "fvcore",
     "ipywidgets>=7.0.0",
-    "IPython",
+    ipython_requirement,
     "fastapi",
     "uvicorn",
     "rich",


### PR DESCRIPTION
This is a known bug and a merge is underway:
https://github.com/ipython/ipython/pull/14054

This is a temporary solution until the ipython version is yanked