### PR TITLE
Bumpversion utility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -322,7 +322,9 @@ class BumpVersionCommand(Command):
 
         # Push the commit to origin.
         self.status(f"Pushing commit to origin/{self.version_branch}")
-        err_code = os.system("git push --force")
+        err_code = os.system(
+            f"git push --force --set-upstream origin {self.version_branch}"
+        )
         if err_code != 0:
             # TODO: undo the commit automatically.
             self._undo()

--- a/setup.py
+++ b/setup.py
@@ -340,6 +340,18 @@ def update_version(version):
         f.writelines(init_py)
 
 
+def get_git_branch():
+    """Return the name of the current branch."""
+    proc = subprocess.Popen(["git branch"], stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    if err is not None:
+        raise RuntimeError(f"Error finding git branch: {err}")
+    out = out.decode("utf-8").split("\n")
+    current_branch = [line for line in out if line.startswith("*")][0]
+    current_branch = current_branch.replace("*", "").strip()
+    return current_branch
+
+
 # Where the magic happens:
 setup(
     name=NAME,

--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ class BumpVersionCommand(Command):
 
         # Return to the original branch
         os.system(f"git checkout {self.base_branch}")
-        os.system(f"git branch -D {version_branch}")
+        os.system(f"git branch -D {self.version_branch}")
 
     def run(self):
         self.status("Checking current branch is 'main'")

--- a/setup.py
+++ b/setup.py
@@ -240,7 +240,6 @@ class BumpVersionCommand(Command):
     user_options = [
         ("version=", "v", "the new version number"),
     ]
-    updated_files = ["meerkat/version.py", "meerkat/interactive/app/package.json"]
 
     @staticmethod
     def status(s):
@@ -251,6 +250,10 @@ class BumpVersionCommand(Command):
         self.version = None
         self.base_branch = None
         self.version_branch = None
+        self.updated_files = [
+            "meerkat/version.py",
+            "meerkat/interactive/app/package.json",
+        ]
 
     def finalize_options(self):
         # This package cannot be imported at top level because it
@@ -268,8 +271,8 @@ class BumpVersionCommand(Command):
             )
 
     def _undo(self):
-        os.system(f"git restore --staged {' '.join(updated_files)}")
-        os.system(f"git checkout -- {' '.join(updated_files)}")
+        os.system(f"git restore --staged {' '.join(self.updated_files)}")
+        os.system(f"git checkout -- {' '.join(self.updated_files)}")
 
         # Return to the original branch
         os.system(f"git checkout {self.base_branch}")
@@ -309,8 +312,8 @@ class BumpVersionCommand(Command):
         #     self._undo()
         #     raise RuntimeError("Failed to update version.")
 
-        self.status(f"Adding {', '.join(updated_files)} to git")
-        err_code = os.system(f"git add {' '.join(updated_files)}")
+        self.status(f"Adding {', '.join(self.updated_files)} to git")
+        err_code = os.system(f"git add {' '.join(self.updated_files)}")
         if err_code != 0:
             self._undo()
             raise RuntimeError("Failed to add file to git.")

--- a/setup.py
+++ b/setup.py
@@ -240,6 +240,7 @@ class BumpVersionCommand(Command):
     user_options = [
         ("version=", "v", "the new version number"),
     ]
+    updated_files = ["meerkat/version.py", "meerkat/interactive/app/package.json"]
 
     @staticmethod
     def status(s):
@@ -267,8 +268,8 @@ class BumpVersionCommand(Command):
             )
 
     def _undo(self):
-        os.system("git restore --staged meerkat/version.py")
-        os.system("git checkout -- meerkat/version.py")
+        os.system(f"git restore --staged {' '.join(updated_files)}")
+        os.system(f"git checkout -- {' '.join(updated_files)}")
 
         # Return to the original branch
         os.system(f"git checkout {self.base_branch}")
@@ -308,8 +309,8 @@ class BumpVersionCommand(Command):
         #     self._undo()
         #     raise RuntimeError("Failed to update version.")
 
-        self.status("Adding meerkat/version.py to git")
-        err_code = os.system("git add meerkat/version.py")
+        self.status(f"Adding {', '.join(updated_files)} to git")
+        err_code = os.system(f"git add {' '.join(updated_files)}")
         if err_code != 0:
             self._undo()
             raise RuntimeError("Failed to add file to git.")

--- a/setup.py
+++ b/setup.py
@@ -277,11 +277,11 @@ class BumpVersionCommand(Command):
     def run(self):
         self.status("Checking current branch is 'main'")
         self.base_branch = current_branch = get_git_branch()
-        if current_branch != "main":
-            raise RuntimeError(
-                "You can only bump the version from the 'main' branch. "
-                "You are currently on the '{}' branch.".format(current_branch)
-            )
+        # if current_branch != "main":
+        #     raise RuntimeError(
+        #         "You can only bump the version from the 'main' branch. "
+        #         "You are currently on the '{}' branch.".format(current_branch)
+        #     )
 
         self.status("Pulling latest changes from origin")
         err_code = os.system("git pull")
@@ -336,6 +336,9 @@ class BumpVersionCommand(Command):
 
 
 def update_version(version):
+    import json
+
+    # Update python.
     ver_path = convert_path("meerkat/version.py")
     init_py = [
         line if not line.startswith("__version__") else f'__version__ = "{version}"\n'
@@ -343,6 +346,14 @@ def update_version(version):
     ]
     with open(ver_path, "w") as f:
         f.writelines(init_py)
+
+    # Update npm.
+    ver_path = convert_path("meerkat/interactive/app/package.json")
+    with open(ver_path, "r") as f:
+        package_json = json.load(f)
+    package_json["version"] = version
+    with open(ver_path, "w") as f:
+        json.dump(package_json, f, indent=4)
 
 
 def get_git_branch():

--- a/setup.py
+++ b/setup.py
@@ -277,11 +277,11 @@ class BumpVersionCommand(Command):
     def run(self):
         self.status("Checking current branch is 'main'")
         self.base_branch = current_branch = get_git_branch()
-        # if current_branch != "main":
-        #     raise RuntimeError(
-        #         "You can only bump the version from the 'main' branch. "
-        #         "You are currently on the '{}' branch.".format(current_branch)
-        #     )
+        if current_branch != "main":
+            raise RuntimeError(
+                "You can only bump the version from the 'main' branch. "
+                "You are currently on the '{}' branch.".format(current_branch)
+            )
 
         self.status("Pulling latest changes from origin")
         err_code = os.system("git pull")

--- a/setup.py
+++ b/setup.py
@@ -330,6 +330,8 @@ class BumpVersionCommand(Command):
             self._undo()
             raise RuntimeError("Failed to push commit to origin.")
 
+        os.system(f"git checkout {self.base_branch}")
+        os.system(f"git branch -D {self.version_branch}")
         sys.exit()
 
 

--- a/setup.py
+++ b/setup.py
@@ -325,6 +325,7 @@ class BumpVersionCommand(Command):
         err_code = os.system("git push --force")
         if err_code != 0:
             # TODO: undo the commit automatically.
+            self._undo()
             raise RuntimeError("Failed to push commit to origin.")
 
         sys.exit()

--- a/setup.py
+++ b/setup.py
@@ -277,11 +277,11 @@ class BumpVersionCommand(Command):
     def run(self):
         self.status("Checking current branch is 'main'")
         self.base_branch = current_branch = get_git_branch()
-        if current_branch != "main":
-            raise RuntimeError(
-                "You can only bump the version from the 'main' branch. "
-                "You are currently on the '{}' branch.".format(current_branch)
-            )
+        # if current_branch != "main":
+        #     raise RuntimeError(
+        #         "You can only bump the version from the 'main' branch. "
+        #         "You are currently on the '{}' branch.".format(current_branch)
+        #     )
 
         self.status("Pulling latest changes from origin")
         err_code = os.system("git pull")


### PR DESCRIPTION
To bump the version, use
```bash
python setup.py bumpversion --version <version>
# eg. python setup.py bumpversion --version 0.4.10
```

This will bump the python and npm versions, commit the changes to a new branch `bumpversion/v<version>`, and push the changes to github.

The user will be responsible for opening a PR from the branch to main